### PR TITLE
Feature/user roles

### DIFF
--- a/app/controllers/backoffice/case_studies_controller.rb
+++ b/app/controllers/backoffice/case_studies_controller.rb
@@ -1,9 +1,14 @@
 class Backoffice::CaseStudiesController < BackofficeController
 
   before_action :set_case_study, only: [:show, :edit, :update, :destroy]
+  before_action :restrict_access, only: [:edit, :update, :destroy]
 
   def index
-    @case_studies = CaseStudy.all
+    @case_studies = if current_user.is_admin?
+                      CaseStudy.all
+                    else
+                      current_user.organization.case_studies
+                    end
   end
 
   def show
@@ -73,6 +78,13 @@ class Backoffice::CaseStudiesController < BackofficeController
         :tag_list,
         contacts_attributes: [:id, :body, :logo, :website, :_destroy]
       )
+    end
+
+    def restrict_access
+      unless current_user.is_admin? || current_user.can_manage?(@case_study)
+        redirect_to backoffice_case_studies_path,
+          error: "You can only manage your Organization's case studies."
+      end
     end
 
 end

--- a/app/controllers/backoffice/case_studies_controller.rb
+++ b/app/controllers/backoffice/case_studies_controller.rb
@@ -1,7 +1,7 @@
 class Backoffice::CaseStudiesController < BackofficeController
 
   before_action :set_case_study, only: [:show, :edit, :update, :destroy]
-  before_action :restrict_access, only: [:edit, :update, :destroy]
+  before_action :restrict_access!, only: [:edit, :update, :destroy]
 
   def index
     @case_studies = if current_user.is_admin?
@@ -80,7 +80,7 @@ class Backoffice::CaseStudiesController < BackofficeController
       )
     end
 
-    def restrict_access
+    def restrict_access!
       unless current_user.is_admin? || current_user.can_manage?(@case_study)
         redirect_to backoffice_case_studies_path,
           error: "You can only manage your Organization's case studies."

--- a/app/controllers/backoffice/organizations_controller.rb
+++ b/app/controllers/backoffice/organizations_controller.rb
@@ -1,0 +1,51 @@
+class OrganizationsController < BackofficeController
+
+  before_action :set_organization, only: [:edit, :update, :destroy]
+  before_action :authorize_admins!
+
+  def index
+    @organizations = Organization.order(:name)
+  end
+
+  def new
+    @organization = Organization.new
+  end
+
+  def create
+    @organization = Organization.new(organizations_params)
+    if @organization.save
+      redirect_to backoffice_organizations_path,
+        notice: 'Organization created successfully'
+    else
+      render :new
+    end
+  end
+
+  def edit
+  end
+
+  def update
+    if @organization.update(organizations_params)
+      redirect_to backoffice_organizations_path,
+        notice: 'Organization updated successfully'
+    else
+      render :edit
+    end
+  end
+
+  def destroy
+    @organization.destroy
+    redirect_to backoffice_organizations_path,
+      notice: 'Organization deleted successfully'
+  end
+
+  private
+
+  def set_organization
+    @organization = Organization.find(params[:id])
+  end
+
+  def organizations_params
+    params.require(:organization).permit(:name)
+  end
+end

--- a/app/controllers/backoffice/organizations_controller.rb
+++ b/app/controllers/backoffice/organizations_controller.rb
@@ -1,4 +1,4 @@
-class OrganizationsController < BackofficeController
+class Backoffice::OrganizationsController < BackofficeController
 
   before_action :set_organization, only: [:edit, :update, :destroy]
   before_action :authorize_admins!

--- a/app/controllers/backoffice/organizations_controller.rb
+++ b/app/controllers/backoffice/organizations_controller.rb
@@ -4,7 +4,7 @@ class OrganizationsController < BackofficeController
   before_action :authorize_admins!
 
   def index
-    @organizations = Organization.order(:name)
+    @organizations = Organization.all
   end
 
   def new

--- a/app/controllers/backoffice/users_controller.rb
+++ b/app/controllers/backoffice/users_controller.rb
@@ -1,6 +1,7 @@
 class Backoffice::UsersController < BackofficeController
 
   before_action :set_user, only: [:edit, :update, :destroy]
+  before_action :set_organizations, only: [:edit, :new]
 
   def index
     @users = User.where.not(id: current_user)
@@ -16,6 +17,7 @@ class Backoffice::UsersController < BackofficeController
       redirect_to edit_backoffice_user_path(@user),
         notice: 'User created successfully.'
     else
+      set_organizations
       render :new
     end
   end
@@ -28,6 +30,7 @@ class Backoffice::UsersController < BackofficeController
       redirect_to edit_backoffice_user_path(@user),
         notice: 'User updated successfully.'
     else
+      set_organizations
       render :edit
     end
   end
@@ -45,6 +48,10 @@ class Backoffice::UsersController < BackofficeController
 
     def user_params
       params.require(:user).permit!
+    end
+
+    def set_organizations
+      @organizations = Organization.all
     end
 
 end

--- a/app/controllers/backoffice/users_controller.rb
+++ b/app/controllers/backoffice/users_controller.rb
@@ -14,7 +14,7 @@ class Backoffice::UsersController < BackofficeController
   def create
     @user = User.new(user_params)
     if @user.save
-      redirect_to edit_backoffice_user_path(@user),
+      redirect_to backoffice_users_path,
         notice: 'User created successfully.'
     else
       set_organizations
@@ -26,8 +26,8 @@ class Backoffice::UsersController < BackofficeController
   end
 
   def update
-    if @user.update(page_params)
-      redirect_to edit_backoffice_user_path(@user),
+    if @user.update(user_params)
+      redirect_to backoffice_users_path,
         notice: 'User updated successfully.'
     else
       set_organizations

--- a/app/controllers/backoffice/users_controller.rb
+++ b/app/controllers/backoffice/users_controller.rb
@@ -6,7 +6,7 @@ class Backoffice::UsersController < BackofficeController
   before_action :restrict_access!, only: [:edit, :update, :destroy]
 
   def index
-    @users = User.where.not(id: current_user)
+    @users = User.where.not(id: current_user).order(:email)
   end
 
   def new

--- a/app/controllers/backoffice/users_controller.rb
+++ b/app/controllers/backoffice/users_controller.rb
@@ -2,6 +2,8 @@ class Backoffice::UsersController < BackofficeController
 
   before_action :set_user, only: [:edit, :update, :destroy]
   before_action :set_organizations, only: [:edit, :new]
+  before_action :set_change_pwd, only: [:edit, :update]
+  before_action :restrict_access!, only: [:edit, :update, :destroy]
 
   def index
     @users = User.where.not(id: current_user)
@@ -52,6 +54,17 @@ class Backoffice::UsersController < BackofficeController
 
     def set_organizations
       @organizations = Organization.all
+    end
+
+    def set_change_pwd
+      @change_pwd = params[:change_pwd].presence || false
+    end
+
+    def restrict_access!
+      unless current_user.is_admin? || current_user == @user
+        redirect_to backoffice_users_path,
+          error: "You are not authorized to access this page."
+      end
     end
 
 end

--- a/app/controllers/backoffice_controller.rb
+++ b/app/controllers/backoffice_controller.rb
@@ -5,4 +5,10 @@ class BackofficeController < ActionController::Base
   before_action :authenticate_user!
 
   layout 'backoffice'
+
+  private
+
+  def authorize_admins!
+    redirect_to backoffice_case_studies_path unless current_user.is_admin?
+  end
 end

--- a/app/models/case_study.rb
+++ b/app/models/case_study.rb
@@ -6,6 +6,7 @@ class CaseStudy < ActiveRecord::Base
 
   has_many :contacts
   has_many :pages
+  belongs_to :organization
   has_attached_file :cover_image, styles: {
     medium: '385x200#',
     large: '1920x1080#'

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -1,0 +1,2 @@
+class Organization < ActiveRecord::Base
+end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -1,2 +1,3 @@
 class Organization < ActiveRecord::Base
+  has_many :case_studies
 end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -2,4 +2,6 @@ class Organization < ActiveRecord::Base
   default_scope { order(:name) }
 
   has_many :case_studies
+
+  validates :name, presence: true
 end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -1,3 +1,5 @@
 class Organization < ActiveRecord::Base
+  default_scope { order(:name) }
+
   has_many :case_studies
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,5 +4,8 @@ class User < ActiveRecord::Base
   devise :database_authenticatable,
          :recoverable, :rememberable, :trackable, :validatable
 
-  validates :email, presence: true, format: { with: /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i }
+  validates :email, presence: true,
+    format: { with: /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i }
+
+  belongs_to :organization
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,4 +8,10 @@ class User < ActiveRecord::Base
     format: { with: /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i }
 
   belongs_to :organization
+
+  def can_manage? case_study
+    return true if is_admin?
+    return false if !organization
+    organization_id == case_study.organization_id
+  end
 end

--- a/app/views/backoffice/organizations/_form.html.slim
+++ b/app/views/backoffice/organizations/_form.html.slim
@@ -1,0 +1,8 @@
+.form-row
+  = f.input :name, required: true, autofocus: true
+.form-row._center
+  - unless @organization.new_record?
+    = link_to t('delete'), backoffice_organization_path(@organization),
+      method: :delete, data: { confirm: t('confirm_sure') },
+      class: 'btn -primary -alt'
+  = f.button :submit, class: 'btn -primary'

--- a/app/views/backoffice/organizations/edit.html.slim
+++ b/app/views/backoffice/organizations/edit.html.slim
@@ -1,0 +1,12 @@
+section.l-main
+
+  header.header
+    .wrap: .row
+      .grid-sm-6
+        h1 = @organization.name
+
+  .content
+    .wrap: .row
+      .grid-sm-6.offset-sm-3
+        = simple_form_for [:backoffice, @organization] do |f|
+          = render 'form', f: f

--- a/app/views/backoffice/organizations/index.html.slim
+++ b/app/views/backoffice/organizations/index.html.slim
@@ -1,0 +1,26 @@
+section.l-main
+  header.header
+    .wrap: .row
+      .grid-sm-8
+        h1 = t 'organizations'
+
+      .grid-sm-4._vcenter._right
+        .btns-toolbar
+          = link_to t('add organization'), new_backoffice_organization_path, class: 'btn'
+
+  .content
+    .wrap: .row
+      .grid-sm-8.offset-sm-2
+
+        table.data-table
+          tr
+            th = t('name')
+            th = t('actions')
+
+          - @organizations.each do |org|
+            tr
+              td = link_to org.name, edit_backoffice_organization_path(org)
+              td
+                .btns-toolbar
+                  = link_to t('edit'), edit_backoffice_organization_path(org), class: 'btn -alt'
+                  = link_to t('delete'), backoffice_organization_path(org), method: :delete, data: { confirm: t('confirm_sure') }, class: 'btn _alt'

--- a/app/views/backoffice/organizations/new.html.slim
+++ b/app/views/backoffice/organizations/new.html.slim
@@ -1,0 +1,12 @@
+section.l-main
+
+  header.header
+    .wrap: .row
+      .grid-sm-6
+        h1 = t 'create_organization'
+
+  .content
+    .wrap: .row
+      .grid-sm-6.offset-sm-3
+        = simple_form_for [:backoffice, @organization] do |f|
+          = render 'form', f: f

--- a/app/views/backoffice/partials/_header.html.slim
+++ b/app/views/backoffice/partials/_header.html.slim
@@ -12,5 +12,6 @@ header.l-header.-bo
           ul
             li = link_to t('case_studies'), backoffice_case_studies_path
             li = link_to t('users'), backoffice_users_path
-            - if user_signed_in?
-              li = link_to t('logout'), destroy_user_session_path, method: 'delete'
+            - if current_user.is_admin?
+              li = link_to t('organizations'), backoffice_organizations_path
+            li = link_to t('logout'), destroy_user_session_path, method: 'delete'

--- a/app/views/backoffice/users/_form.html.slim
+++ b/app/views/backoffice/users/_form.html.slim
@@ -4,6 +4,9 @@
   = f.input :password, required: true, hint: ("#{@minimum_password_length} characters minimum" if @minimum_password_length) 
 .form-row
   = f.input :password_confirmation, required: true
+- if current_user.is_admin?
+  .form-row
+    = f.input :organization, collection: @organizations
 .form-row._center
   - if @user[:id]
     = link_to t('delete'), backoffice_user_path(@user), method: :delete, data: { confirm: t('confirm_sure') }, class: 'btn -primary -alt'

--- a/app/views/backoffice/users/_form.html.slim
+++ b/app/views/backoffice/users/_form.html.slim
@@ -6,7 +6,7 @@
   = f.input :password_confirmation, required: true
 - if current_user.is_admin?
   .form-row
-    = f.input :organization, collection: @organizations
+    = f.input :organization_id, collection: @organizations
 .form-row._center
   - if @user[:id]
     = link_to t('delete'), backoffice_user_path(@user), method: :delete, data: { confirm: t('confirm_sure') }, class: 'btn -primary -alt'

--- a/app/views/backoffice/users/_form.html.slim
+++ b/app/views/backoffice/users/_form.html.slim
@@ -10,6 +10,8 @@
 - if current_user.is_admin? && !@change_pwd
   .form-row
     = f.input :organization_id, collection: @organizations
+  .form-row
+    = f.input :is_admin, type: 'check-box', label: 'Admin'
 .form-row._center
   - unless @user.new_record?
     = link_to t('delete'), backoffice_user_path(@user), method: :delete,

--- a/app/views/backoffice/users/_form.html.slim
+++ b/app/views/backoffice/users/_form.html.slim
@@ -1,13 +1,17 @@
-.form-row
-  = f.input :email, required: true, autofocus: true
-.form-row
-  = f.input :password, required: true, hint: ("#{@minimum_password_length} characters minimum" if @minimum_password_length) 
-.form-row
-  = f.input :password_confirmation, required: true
-- if current_user.is_admin?
+- if !@change_pwd
+  .form-row
+    = f.input :email, required: true, autofocus: true
+- if @user.new_record? || ((current_user.is_admin? || current_user == @user) && @change_pwd)
+  .form-row
+    = f.input :password, required: true,
+      hint: ("#{@minimum_password_length} characters minimum" if @minimum_password_length)
+  .form-row
+    = f.input :password_confirmation, required: true
+- if current_user.is_admin? && !@change_pwd
   .form-row
     = f.input :organization_id, collection: @organizations
 .form-row._center
-  - if @user[:id]
-    = link_to t('delete'), backoffice_user_path(@user), method: :delete, data: { confirm: t('confirm_sure') }, class: 'btn -primary -alt'
+  - unless @user.new_record?
+    = link_to t('delete'), backoffice_user_path(@user), method: :delete,
+      data: { confirm: t('confirm_sure') }, class: 'btn -primary -alt'
   = f.button :submit, class: 'btn -primary'

--- a/app/views/backoffice/users/edit.html.slim
+++ b/app/views/backoffice/users/edit.html.slim
@@ -9,4 +9,5 @@ section.l-main
     .wrap: .row
       .grid-sm-6.offset-sm-3
         = simple_form_for @user, url: backoffice_user_path do |f|
+          = hidden_field_tag :change_pwd, @change_pwd
           = render 'form', f: f

--- a/app/views/backoffice/users/index.html.slim
+++ b/app/views/backoffice/users/index.html.slim
@@ -12,21 +12,22 @@ section.l-main
   .content
     .wrap: .row
       .grid-sm-8.offset-sm-2
-        
         table.data-table
           tr
             th = t('email')
             th = t('organization')
             th = t('role')
             th = t('actions')
-            
           - @users.each do |u|
             tr
-              td = link_to u.email, edit_backoffice_user_path(u)
+              td = u.email
               td = u.organization.try(:name)
               td = u.is_admin? ? "Admin" : "Contributor"
               td
                 .btns-toolbar
                   - if current_user.is_admin? || current_user == u
                     = link_to t('edit'), edit_backoffice_user_path(u), class: 'btn -alt'
+                    = link_to t('change_password'),
+                      edit_backoffice_user_path(u, change_pwd: true),
+                      class: 'btn -alt'
                   = link_to t('delete'), backoffice_user_path(u), method: :delete, data: { confirm: t('confirm_sure') }, class: 'btn _alt'

--- a/app/views/backoffice/users/index.html.slim
+++ b/app/views/backoffice/users/index.html.slim
@@ -16,15 +16,15 @@ section.l-main
         table.data-table
           tr
             th = t('email')
-            th = t('organisation')
+            th = t('organization')
             th = t('role')
             th = t('actions')
             
           - @users.each do |u|
             tr
               td = link_to u.email, edit_backoffice_user_path(u)
-              td
-              td
+              td = u.organization.try(:name)
+              td = u.is_admin? ? "Admin" : "Contributor"
               td
                 .btns-toolbar
                   = link_to t('edit'), edit_backoffice_user_path(u), class: 'btn -alt'

--- a/app/views/backoffice/users/index.html.slim
+++ b/app/views/backoffice/users/index.html.slim
@@ -27,5 +27,6 @@ section.l-main
               td = u.is_admin? ? "Admin" : "Contributor"
               td
                 .btns-toolbar
-                  = link_to t('edit'), edit_backoffice_user_path(u), class: 'btn -alt'
+                  - if current_user.is_admin? || current_user == u
+                    = link_to t('edit'), edit_backoffice_user_path(u), class: 'btn -alt'
                   = link_to t('delete'), backoffice_user_path(u), method: :delete, data: { confirm: t('confirm_sure') }, class: 'btn _alt'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,6 +34,7 @@ en:
   contact: 'Contact'
   create_case_study: 'Create new case study'
   create_user: 'Create user'
+  create_organization: 'Create Organization'
   data: 'Data'
   data_origin: 'Data origin'
   date:
@@ -46,6 +47,7 @@ en:
   duplicate: 'Duplicate'
   edit: 'Edit'
   email: 'Email'
+  name: 'Name'
   earth_observation: 'Earth observation'
   explore_map: 'Explore the map'
   forgot_password: 'Forgot your password?'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,6 +34,7 @@ en:
   contact: 'Contact'
   create_case_study: 'Create new case study'
   create_user: 'Create user'
+  change_password: 'Change password'
   create_organization: 'Create Organization'
   data: 'Data'
   data_origin: 'Data origin'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -55,7 +55,7 @@ en:
   login: 'Login'
   logout: 'Logout'
   map: 'Map'
-  organisation: 'Organisation'
+  organization: 'Organization'
   or: 'or'
   page: 'Page'
   parnertship_convened: 'Partnership convened by'
@@ -81,3 +81,4 @@ en:
   unpublish: "Unpublish"
   unpublished: "Unpublished"
   users: "Users"
+  organizations: "Organizations"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -29,6 +29,7 @@ en:
   browse: 'browse'
   case_details: 'Case details'
   case_studies: 'Case studies'
+  organizations: 'Organizations'
   confirm_sure: 'Are you sure?'
   contact: 'Contact'
   create_case_study: 'Create new case study'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
     end
 
     resources :users, except: [:show]
+    resources :organizations, except: [:show]
 
     root 'case_studies#index', as: 'dashboard'
   end

--- a/db/migrate/20160121123019_create_organizations.rb
+++ b/db/migrate/20160121123019_create_organizations.rb
@@ -1,0 +1,9 @@
+class CreateOrganizations < ActiveRecord::Migration
+  def change
+    create_table :organizations do |t|
+      t.string :name
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20160121123739_add_organization_id_to_users.rb
+++ b/db/migrate/20160121123739_add_organization_id_to_users.rb
@@ -1,0 +1,5 @@
+class AddOrganizationIdToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :organization_id, :integer
+  end
+end

--- a/db/migrate/20160121165720_add_is_admin_to_users.rb
+++ b/db/migrate/20160121165720_add_is_admin_to_users.rb
@@ -1,0 +1,5 @@
+class AddIsAdminToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :is_admin, :boolean, default: false
+  end
+end

--- a/db/migrate/20160121172035_add_organization_id_to_case_studies.rb
+++ b/db/migrate/20160121172035_add_organization_id_to_case_studies.rb
@@ -1,0 +1,5 @@
+class AddOrganizationIdToCaseStudies < ActiveRecord::Migration
+  def change
+    add_column :case_studies, :organization_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160118155621) do
+ActiveRecord::Schema.define(version: 20160121165720) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -83,6 +83,12 @@ ActiveRecord::Schema.define(version: 20160118155621) do
 
   add_index "interest_points", ["page_id"], name: "index_interest_points_on_page_id", using: :btree
 
+  create_table "organizations", force: :cascade do |t|
+    t.string   "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "pages", force: :cascade do |t|
     t.string   "title",                               null: false
     t.integer  "page_type",               default: 1
@@ -123,18 +129,20 @@ ActiveRecord::Schema.define(version: 20160118155621) do
   add_index "tags", ["name"], name: "index_tags_on_name", unique: true, using: :btree
 
   create_table "users", force: :cascade do |t|
-    t.string   "email",                  default: "", null: false
-    t.string   "encrypted_password",     default: "", null: false
+    t.string   "email",                  default: "",    null: false
+    t.string   "encrypted_password",     default: "",    null: false
     t.string   "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",          default: 0,  null: false
+    t.integer  "sign_in_count",          default: 0,     null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
     t.string   "current_sign_in_ip"
     t.string   "last_sign_in_ip"
-    t.datetime "created_at",                          null: false
-    t.datetime "updated_at",                          null: false
+    t.datetime "created_at",                             null: false
+    t.datetime "updated_at",                             null: false
+    t.integer  "organization_id"
+    t.boolean  "is_admin",               default: false
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160121165720) do
+ActiveRecord::Schema.define(version: 20160121172035) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -29,6 +29,7 @@ ActiveRecord::Schema.define(version: 20160121165720) do
     t.datetime "cover_image_updated_at"
     t.decimal  "lat"
     t.decimal  "lng"
+    t.integer  "organization_id"
   end
 
   create_table "charts", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,14 +8,21 @@
 
 if Rails.env == 'development'
 
+  vizz = Organization.create(name: 'Vizzuality')
+  monsters = Organization.create(name: 'Monsters Inc.')
+
   users = [
-    { email: 'admin@example.com', password: 'password', password_confirmation: 'password' },
-    { email: 'user1@example.com', password: 'password', password_confirmation: 'password' },
-    { email: 'user2@example.com', password: 'password', password_confirmation: 'password' }
+    { email: 'admin@example.com', password: 'password', password_confirmation: 'password',
+      is_admin: true, organization_id: vizz.id },
+    { email: 'user1@example.com', password: 'password',
+      password_confirmation: 'password', organization_id: monsters.id },
+    { email: 'user2@example.com', password: 'password',
+      password_confirmation: 'password', organization_id: monsters.id },
   ]
 
   case_studies = [
-    { title: 'Multi-hazard Vulnerability Assessment in Ho Chi Minh City and Yogyakarta', published: true }
+    { title: 'Multi-hazard Vulnerability Assessment in Ho Chi Minh City and Yogyakarta',
+      published: true, organization_id: monsters.id }
   ]
 
   User.create(users)
@@ -23,7 +30,7 @@ if Rails.env == 'development'
 
   CaseStudy.create(case_studies)
   puts "Case studies created successfully"
-  
+
 end
 
 Chart.create([{name: 'pie'}, {name: 'bar'}, {name: 'line'}])

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -22,7 +22,8 @@ if Rails.env == 'development'
 
   case_studies = [
     { title: 'Multi-hazard Vulnerability Assessment in Ho Chi Minh City and Yogyakarta',
-      published: true, organization_id: monsters.id }
+      published: true, organization_id: monsters.id,
+      lat: 38.7755940, lng: -9.1353670, template: 1 }
   ]
 
   User.create(users)

--- a/spec/factories/case_studies.rb
+++ b/spec/factories/case_studies.rb
@@ -1,0 +1,11 @@
+require 'faker'
+
+FactoryGirl.define do
+  factory :case_study do |f|
+    f.title { Faker::Lorem.sentence }
+    f.lat { 23 }
+    f.lng { 23 }
+    f.template { 1 }
+    f.association :organization, factory: :organization
+  end
+end

--- a/spec/factories/organizations.rb
+++ b/spec/factories/organizations.rb
@@ -1,0 +1,7 @@
+require 'faker'
+
+FactoryGirl.define do
+  factory :organization do |f|
+    f.name { Faker::Name.name }
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -5,5 +5,6 @@ FactoryGirl.define do
     f.email { Faker::Internet.email }
     f.password { Faker::Internet.password }
     f.password_confirmation { |u| u.password }
+    f.association :organization, factory: :organization
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -7,4 +7,36 @@ RSpec.describe User, type: :model do
     expect(user).to be_valid
   end
 
+  context ".can_manage?" do
+    before(:each) do
+      @org = FactoryGirl.create(:organization)
+    end
+
+    it "can manage case_studies from its organization" do
+      user = FactoryGirl.create(:user, organization: @org)
+      case_study = FactoryGirl.create(:case_study, organization: @org)
+      expect(user.can_manage?(case_study)).to be(true)
+    end
+
+    it "cannot manage case_studies from other organizations" do
+      user = FactoryGirl.create(:user, organization: @org)
+      case_study = FactoryGirl.create(:case_study)
+      expect(user.can_manage?(case_study)).to be(false)
+    end
+
+    it "cannot manage case_studies if doesn't have an organization" do
+      user = FactoryGirl.create(:user, organization: nil)
+      case_study = FactoryGirl.create(:case_study, organization: @org)
+      expect(user.can_manage?(case_study)).to be(false)
+    end
+
+    it "can manage any case_study if is_admin" do
+      user = FactoryGirl.create(:user, is_admin: true)
+      case_study = FactoryGirl.create(:case_study, organization: @org)
+      case_study2 = FactoryGirl.create(:case_study)
+      expect(user.can_manage?(case_study)).to be(true)
+      expect(user.can_manage?(case_study2)).to be(true)
+    end
+  end
+
 end


### PR DESCRIPTION
In this PR:
- Adds an Organization model
- Users and CaseStudies belong to Organization
- Adds access controls to prevent users from seeing and editing case studies from other organizations
- Adds is_admin attribute to users
- Restricts access to admins for organization management
- Updates backoffice user«s form to allow that admins change a users' organization
- Adds a separate link in users index page to allow changing a user's password separately from editing the other fields

This PR requires you to run

```
rake db:migrate
```

Some questions that I have:
- I saw that the user doesn't see itself in the user list
- How can a user change it's own password?

Happy to discuss any of this.
