### PR TITLE
Feature/cartocss input backoffice

### DIFF
--- a/app/assets/javascripts/helpers/helper.js
+++ b/app/assets/javascripts/helpers/helper.js
@@ -33,4 +33,16 @@
     return 'rgba('+r+','+g+','+b+','+opacity/100+')';
   };
 
+  root.App.Helper.switchInputColors = function(value) {
+    if (! !!value) return null;
+
+    var values = value.split('\n'),
+        categColor = {};
+    for (var i = 0; i < values.length; i ++) {
+      if (values[i].length < 1) break;
+      categColor[values[i].split('-')[1]] =  values[i].split('-')[0];
+    }
+    return categColor;
+  }
+
 })(window);

--- a/app/assets/javascripts/views/map_file_categories_view.js
+++ b/app/assets/javascripts/views/map_file_categories_view.js
@@ -24,6 +24,7 @@
       this.rasterCategory = this.el.getElementsByClassName('raster-category')[0];
       this.columnsContainer = this.el.getElementsByClassName('box-list')[0];
       this.customColumsInput = this.el.getElementsByClassName('custom_columns_colors');
+      this.rasterColorInput = this.el.getElementsByClassName('raster_color_input');
       this.palette = App.CartoCSS['Theme' + this.data.caseStudy.template].palette1;
     },
 
@@ -193,7 +194,12 @@
 
     refreshCategories: function(columns) {
       var self = this;
-      var colors = App.Helper.deserialize(this.customColumsInput[0].value);
+      if (this.rasterColorInput[0].value) {
+        // Step over current given values with the ones pasted in the CartoCSS formated file
+        var colors = App.Helper.switchInputColors(this.rasterColorInput[0].value);
+      } else {
+        var colors = App.Helper.deserialize(this.customColumsInput[0].value);
+      }
       var paletteLenght = this.palette.length;
       var count = 0;
 

--- a/app/controllers/backoffice/pages_controller.rb
+++ b/app/controllers/backoffice/pages_controller.rb
@@ -84,7 +84,7 @@ class Backoffice::PagesController < BackofficeController
         :body,
         :background,
         :color_palette,
-        :custom_basemap,
+        :raster_custom_colors,
         :page_type,
         :chart_type_list,
         :case_study_id,

--- a/app/controllers/backoffice/pages_controller.rb
+++ b/app/controllers/backoffice/pages_controller.rb
@@ -97,6 +97,7 @@ class Backoffice::PagesController < BackofficeController
           :shapefile,
           :layer_column,
           :layer_column_alias,
+          :raster_color_input,
           :raster_type,
           :raster_categories,
           :custom_columns_colors

--- a/app/controllers/backoffice/pages_controller.rb
+++ b/app/controllers/backoffice/pages_controller.rb
@@ -84,7 +84,7 @@ class Backoffice::PagesController < BackofficeController
         :body,
         :background,
         :color_palette,
-        :raster_custom_colors,
+        :custom_basemap,
         :page_type,
         :chart_type_list,
         :case_study_id,

--- a/app/views/backoffice/pages/_edit_form.html.slim
+++ b/app/views/backoffice/pages/_edit_form.html.slim
@@ -75,7 +75,7 @@
                   = d.input_field :custom_columns_colors, as: :hidden, value: d.object.custom_columns_colors, class: "custom_columns_colors"
                   = d.input_field :raster_type, as: :hidden, value: d.object.raster_type, class: "raster-type"
                   = d.input_field :raster_categories, as: :hidden, value: d.object.raster_categories, class: "raster-category"
-                  = f.input :raster_color_input, input_html: {class:"-large"}, placeholder: "CUSTOMIZED COLORS\nPaste code here\n\nrgba(255,255,255,0.5)-column1\nrgba(73,73,73,0.7)-column2\n"
+                  = d.input :raster_color_input, input_html: {class:"-large"}, placeholder: "CUSTOMIZED COLORS\nPaste code here\n\nrgba(255,255,255,0.5)-column1\nrgba(73,73,73,0.7)-column2\n"
       = f.input_field :color_palette, as: :hidden, value: (@page.color_palette.to_i.blank? ? 1 : @page.color_palette.to_i), class: 'input', id:"pallete"
 
   .form-row

--- a/app/views/backoffice/pages/_edit_form.html.slim
+++ b/app/views/backoffice/pages/_edit_form.html.slim
@@ -75,7 +75,7 @@
                   = d.input_field :custom_columns_colors, as: :hidden, value: d.object.custom_columns_colors, class: "custom_columns_colors"
                   = d.input_field :raster_type, as: :hidden, value: d.object.raster_type, class: "raster-type"
                   = d.input_field :raster_categories, as: :hidden, value: d.object.raster_categories, class: "raster-category"
-                  = d.input :raster_color_input, input_html: {class:"-large"}, placeholder: "CUSTOMIZED COLORS\nPaste code here\n\nrgba(255,255,255,0.5)-column1\nrgba(73,73,73,0.7)-column2\n"
+                  = d.input :custom_basemap, input_html: {class:"-large"}, placeholder: "CUSTOMIZED COLORS PER COLUMNS\nPaste code here\n\nrgba(255,255,255,0.5)-column1\nrgba(73,73,73,0.7)-column2\n"
       = f.input_field :color_palette, as: :hidden, value: (@page.color_palette.to_i.blank? ? 1 : @page.color_palette.to_i), class: 'input', id:"pallete"
 
   .form-row

--- a/app/views/backoffice/pages/_edit_form.html.slim
+++ b/app/views/backoffice/pages/_edit_form.html.slim
@@ -75,7 +75,7 @@
                   = d.input_field :custom_columns_colors, as: :hidden, value: d.object.custom_columns_colors, class: "custom_columns_colors"
                   = d.input_field :raster_type, as: :hidden, value: d.object.raster_type, class: "raster-type"
                   = d.input_field :raster_categories, as: :hidden, value: d.object.raster_categories, class: "raster-category"
-        / = f.input :custom_basemap, input_html: {class:"-large"}, placeholder: "CUSTOMIZED CARTOCSS \nPaste code here"
+                  = f.input :raster_custom_colors, input_html: {class:"-large"}, placeholder: "CUSTOMIZED COLORS\nPaste code here\n\nrgba(255,255,255,0.5)-column1\nrgba(73,73,73,0.7)-column2\n"
       = f.input_field :color_palette, as: :hidden, value: (@page.color_palette.to_i.blank? ? 1 : @page.color_palette.to_i), class: 'input', id:"pallete"
 
   .form-row

--- a/app/views/backoffice/pages/_edit_form.html.slim
+++ b/app/views/backoffice/pages/_edit_form.html.slim
@@ -75,7 +75,7 @@
                   = d.input_field :custom_columns_colors, as: :hidden, value: d.object.custom_columns_colors, class: "custom_columns_colors"
                   = d.input_field :raster_type, as: :hidden, value: d.object.raster_type, class: "raster-type"
                   = d.input_field :raster_categories, as: :hidden, value: d.object.raster_categories, class: "raster-category"
-                  = d.input :custom_basemap, input_html: {class:"-large"}, placeholder: "CUSTOMIZED COLORS PER COLUMNS\nPaste code here\n\nrgba(255,255,255,0.5)-column1\nrgba(73,73,73,0.7)-column2\n"
+                  = d.input :raster_color_input, input_html: {class:"-large raster_color_input"}, placeholder: "CUSTOMIZED COLORS PER COLUMNS\nPaste code here\n\nrgba(255,255,255,0.5)-column1\nrgba(73,73,73,0.7)-column2\n"
       = f.input_field :color_palette, as: :hidden, value: (@page.color_palette.to_i.blank? ? 1 : @page.color_palette.to_i), class: 'input', id:"pallete"
 
   .form-row

--- a/app/views/backoffice/pages/_edit_form.html.slim
+++ b/app/views/backoffice/pages/_edit_form.html.slim
@@ -75,7 +75,7 @@
                   = d.input_field :custom_columns_colors, as: :hidden, value: d.object.custom_columns_colors, class: "custom_columns_colors"
                   = d.input_field :raster_type, as: :hidden, value: d.object.raster_type, class: "raster-type"
                   = d.input_field :raster_categories, as: :hidden, value: d.object.raster_categories, class: "raster-category"
-                  = f.input :raster_custom_colors, input_html: {class:"-large"}, placeholder: "CUSTOMIZED COLORS\nPaste code here\n\nrgba(255,255,255,0.5)-column1\nrgba(73,73,73,0.7)-column2\n"
+                  = f.input :custom_basemap, input_html: {class:"-large"}, placeholder: "CUSTOMIZED COLORS\nPaste code here\n\nrgba(255,255,255,0.5)-column1\nrgba(73,73,73,0.7)-column2\n"
       = f.input_field :color_palette, as: :hidden, value: (@page.color_palette.to_i.blank? ? 1 : @page.color_palette.to_i), class: 'input', id:"pallete"
 
   .form-row

--- a/app/views/backoffice/pages/_edit_form.html.slim
+++ b/app/views/backoffice/pages/_edit_form.html.slim
@@ -75,7 +75,7 @@
                   = d.input_field :custom_columns_colors, as: :hidden, value: d.object.custom_columns_colors, class: "custom_columns_colors"
                   = d.input_field :raster_type, as: :hidden, value: d.object.raster_type, class: "raster-type"
                   = d.input_field :raster_categories, as: :hidden, value: d.object.raster_categories, class: "raster-category"
-                  = f.input :custom_basemap, input_html: {class:"-large"}, placeholder: "CUSTOMIZED COLORS\nPaste code here\n\nrgba(255,255,255,0.5)-column1\nrgba(73,73,73,0.7)-column2\n"
+                  = f.input :raster_color_input, input_html: {class:"-large"}, placeholder: "CUSTOMIZED COLORS\nPaste code here\n\nrgba(255,255,255,0.5)-column1\nrgba(73,73,73,0.7)-column2\n"
       = f.input_field :color_palette, as: :hidden, value: (@page.color_palette.to_i.blank? ? 1 : @page.color_palette.to_i), class: 'input', id:"pallete"
 
   .form-row

--- a/db/migrate/20160126122453_add_custom_basemap_column_to_pages.rb
+++ b/db/migrate/20160126122453_add_custom_basemap_column_to_pages.rb
@@ -1,5 +1,5 @@
 class AddCustomBasemapColumnToPages < ActiveRecord::Migration
   def change
-    add_column :pages, :custom_basemap, :text
+    add_column :pages, :raster_custom_colors, :text
   end
 end

--- a/db/migrate/20160126122453_add_custom_basemap_column_to_pages.rb
+++ b/db/migrate/20160126122453_add_custom_basemap_column_to_pages.rb
@@ -1,5 +1,5 @@
 class AddCustomBasemapColumnToPages < ActiveRecord::Migration
   def change
-    add_column :pages, :raster_custom_colors, :text
+    add_column :pages, :custom_basemap, :text
   end
 end

--- a/db/migrate/20160307173229_add_raster_color_input.rb
+++ b/db/migrate/20160307173229_add_raster_color_input.rb
@@ -1,5 +1,5 @@
 class AddRasterColorInput < ActiveRecord::Migration
   def change
-  	add_column :data_layers, :raster_color_input, :string
+  	add_column :data_layers, :raster_color_input, :text, default: 'test'
   end
 end

--- a/db/migrate/20160307173229_add_raster_color_input.rb
+++ b/db/migrate/20160307173229_add_raster_color_input.rb
@@ -1,0 +1,5 @@
+class AddRasterColorInput < ActiveRecord::Migration
+  def change
+  	add_column :data_layers, :raster_color_input, :string
+  end
+end

--- a/db/migrate/20160308095554_add_raster_color_input_to_data_layers.rb
+++ b/db/migrate/20160308095554_add_raster_color_input_to_data_layers.rb
@@ -1,0 +1,5 @@
+class AddRasterColorInputToDataLayers < ActiveRecord::Migration
+  def change
+  	add_column :data_layers, :raster_color_input, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -115,7 +115,7 @@ ActiveRecord::Schema.define(version: 20160229170859) do
     t.string   "basemap",                 default: "terrain"
     t.string   "basemap_url"
     t.text     "body"
-    t.text     "raster_custom_colors"
+    t.text     "custom_basemap"
     t.string   "column_selected"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160229170859) do
+ActiveRecord::Schema.define(version: 20160307173229) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -77,6 +77,7 @@ ActiveRecord::Schema.define(version: 20160229170859) do
     t.datetime "shapefile_updated_at"
     t.string   "raster_type"
     t.string   "raster_categories"
+    t.string   "raster_color_input"
   end
 
   add_index "data_layers", ["page_id"], name: "index_data_layers_on_page_id", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160307173229) do
+ActiveRecord::Schema.define(version: 20160308095554) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -77,7 +77,7 @@ ActiveRecord::Schema.define(version: 20160307173229) do
     t.datetime "shapefile_updated_at"
     t.string   "raster_type"
     t.string   "raster_categories"
-    t.string   "raster_color_input"
+    t.text     "raster_color_input"
   end
 
   add_index "data_layers", ["page_id"], name: "index_data_layers_on_page_id", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -115,7 +115,7 @@ ActiveRecord::Schema.define(version: 20160229170859) do
     t.string   "basemap",                 default: "terrain"
     t.string   "basemap_url"
     t.text     "body"
-    t.text     "custom_basemap"
+    t.text     "raster_custom_colors"
     t.string   "column_selected"
   end
 


### PR DESCRIPTION
---

**Caution**: this requires a `rake db:migrate` operation

---

This PR adds a textarea so the user has the option to paste or type his/her previously formatted styles to a given raster.

Take this example:

```
rgba(120,1,255,1)-100
rgba(120,1,255,1)-73.031494140625
rgba(120,1,255,1)-50.2812156677246
rgba(120,1,255,1)-39.80315017700
rgba(120,1,255,1)-24.26181221008
rgba(120,1,255,1)-11.9860019683838
rgba(120,1,255,1)-11.02362155914
```

That produces the following output if saved:
![image](https://cloud.githubusercontent.com/assets/704210/13601631/bd1e6872-e531-11e5-8747-9cce5a8471a8.png)

Cheers!
