### PR TITLE
fill map title input with filename

### DIFF
--- a/app/assets/javascripts/views/map_file_columns_view.js
+++ b/app/assets/javascripts/views/map_file_columns_view.js
@@ -34,6 +34,7 @@
       this.data = this._getAppData();
       this.ignoredColumns = this.options.ignoredColumns;
       this.rasterColumn = this.options.rasterColumn;
+      this.rastertitle = document.getElementById('page_title');
 
       this.isRaster = false;
 
@@ -176,6 +177,7 @@
         var tpl = this._fileTemplate()({
           fileName: this.fileInput.files[0].name
         });
+        this.rastertitle.value = (!!this.rastertitle.value) ? this.rastertitle.value : this.fileInput.files[0].name;
         document.getElementById('filename').insertAdjacentHTML('beforeend', tpl);
       }
       this.el.getElementsByClassName('input-wrapper')[0].classList.add('_hidden');


### PR DESCRIPTION
In case the user hasn't entered any name for the page title when uploading a raster this field is filled in with the filename value.

![image](https://cloud.githubusercontent.com/assets/704210/13605390/a1917bce-e547-11e5-8a69-565ca1a6cde9.png)
