### PR TITLE
Feature/allow remove cdb dataset

### DIFF
--- a/app/assets/javascripts/views/map_file_columns_view.js
+++ b/app/assets/javascripts/views/map_file_columns_view.js
@@ -26,7 +26,7 @@
       'click .item': 'onClickItem',
       'click .remove_fields': 'checkRemoveNewItem',
       'cocoon:after-insert': 'onAddNewItem',
-      'cocoon:after-remove': 'onRemoveNewItem',
+      'cocoon:after-remove': 'onRemoveNewItem'
     },
 
     initialize: function(params) {

--- a/app/assets/javascripts/views/map_file_columns_view.js
+++ b/app/assets/javascripts/views/map_file_columns_view.js
@@ -248,14 +248,20 @@
 
     _confirmRemove: function(name) {
       if (window.confirm("Following dataset will be completely erased: "+ name + ", do you want to continue?")) {
-        this._doRemoveRaster(name);
+        this._doRemoveRaster();
         var target = this.el.querySelectorAll('.-delete.remove_fields')[0];
         target.classList.add('_confirmed');
         target.click();
       }
     },
-    _doRemoveRaster: function(name) {
-
+    _doRemoveRaster: function() {
+      $.ajax({
+          url: '/backoffice/data-layers/' + this.layerId,
+          type: 'DELETE',
+          success: function(result) {
+              console.info('Dataset deleted succesfully')
+          }
+      });
     },
 
     checkRemoveNewItem: function(e) {

--- a/app/assets/javascripts/views/map_file_columns_view.js
+++ b/app/assets/javascripts/views/map_file_columns_view.js
@@ -24,8 +24,9 @@
       'change #map_file': 'onInputChanged',
       'click .close': 'removeFileSelected',
       'click .item': 'onClickItem',
+      'click .remove_fields': 'checkRemoveNewItem',
       'cocoon:after-insert': 'onAddNewItem',
-      'cocoon:after-remove': 'onRemoveNewItem'
+      'cocoon:after-remove': 'onRemoveNewItem',
     },
 
     initialize: function(params) {
@@ -197,11 +198,13 @@
     },
 
     onAddNewItem: function(e) {
-      e.currentTarget.getElementsByClassName('add_fields')[0].classList.add('_hidden');
+      if (!! e.currentTarget.getElementsByClassName('add_fields')[0])
+        e.currentTarget.getElementsByClassName('add_fields')[0].classList.add('_hidden');
     },
 
     onRemoveNewItem: function(e) {
-      e.currentTarget.getElementsByClassName('add_fields')[0].classList.remove('_hidden');
+      if (!! e.currentTarget.getElementsByClassName('add_fields')[0])
+        e.currentTarget.getElementsByClassName('add_fields')[0].classList.remove('_hidden');
     },
 
     onClickItem: function(e) {
@@ -243,6 +246,28 @@
       return data;
     },
 
+    _confirmRemove: function(name) {
+      if (window.confirm("Following dataset will be completely erased: "+ name + ", do you want to continue?")) {
+        this._doRemoveRaster(name);
+        var target = this.el.querySelectorAll('.-delete.remove_fields')[0];
+        target.classList.add('_confirmed');
+        target.click();
+      }
+    },
+    _doRemoveRaster: function(name) {
+
+    },
+
+    checkRemoveNewItem: function(e) {
+      if (!! e.target.classList.contains('_confirmed')) {
+        e.target.classList.remove('_confirmed');
+        return;
+      }
+      if (!! this.el.classList.contains('file-map-input')) {
+        e.stopPropagation();
+        this._confirmRemove(this.el.querySelector('.name p').innerHTML.trim());
+      }      
+    }
   });
 
 })(window.App ||  {});

--- a/app/assets/stylesheets/components/_btn.scss
+++ b/app/assets/stylesheets/components/_btn.scss
@@ -139,6 +139,17 @@
 
     border: 0;
     background-color: transparent;
+    &.-inside-input {
+      position: relative;
+      padding: 0;
+      margin: 0;
+      width: 100%;
+      display: flex;
+      justify-content: flex-start;
+      align-items: center;
+      height: 48px;
+      left: -100%;
+    }
   }
 
   &.-add {

--- a/app/controllers/backoffice/data_layers_controller.rb
+++ b/app/controllers/backoffice/data_layers_controller.rb
@@ -18,4 +18,8 @@ class Backoffice::DataLayersController < ApplicationController
     params.permit(:id)
   end
 
+  def destroy
+    layer = DataLayer.where(id:data_layer_params[:id]).first
+    layer.destroy
+  end
 end

--- a/app/controllers/backoffice/data_layers_controller.rb
+++ b/app/controllers/backoffice/data_layers_controller.rb
@@ -12,6 +12,7 @@ class Backoffice::DataLayersController < BackofficeController
 
   def destroy
     @data_layer.destroy
+    render json: true
   end
 
 

--- a/app/controllers/backoffice/data_layers_controller.rb
+++ b/app/controllers/backoffice/data_layers_controller.rb
@@ -1,25 +1,23 @@
-class Backoffice::DataLayersController < ApplicationController
+class Backoffice::DataLayersController < BackofficeController
 
-  before_action :authenticate_user!
+  before_action :set_data_layer, only: [:show, :destroy]
 
   respond_to :json
 
-  def index
-    if data_layer_params[:id]
-      layer = DataLayer.where(id:data_layer_params[:id]).first
-      body = layer.nil? ? { error:'404', msg: 'Data layer not found', data_layer:{}} : layer
-    else
-      body = { error:'400', msg: 'You need to provide a id', data_layer:{}}
-    end
+  def show
+    body = @data_layer ||
+      { error:'400', msg: 'You need to provide an id', data_layer:{}}
     render json: body
   end
 
-  def data_layer_params
-    params.permit(:id)
+  def destroy
+    @data_layer.destroy
   end
 
-  def destroy
-    layer = DataLayer.where(id:data_layer_params[:id]).first
-    layer.destroy
+
+  private
+
+  def set_data_layer
+    @data_layer = DataLayer.find(params[:id])
   end
 end

--- a/app/models/data_layer.rb
+++ b/app/models/data_layer.rb
@@ -22,19 +22,15 @@ class DataLayer < ActiveRecord::Base
 
 
   validates :shapefile, attachment_presence: true
-  # validates :table_name, presence: true
-  # validates :import_status, presence: true
-  # validates :year, presence: true
 
   attr_accessor :cloning
-
-  # after_create :upload_carto_file, on: :create, unless: :cloning
 
   before_destroy :remove_cartodb_table
 
   def remove_cartodb_table
     layers_same_table = DataLayer.where.not(id: self.id).where(table_name: self.table_name)
     if layers_same_table.empty?
+      puts "Deleting cartodb table #{self.table_name}"
       CartoDb.remove_cartodb_table(self.table_name)
     end
   end

--- a/app/views/backoffice/pages/_data_layers_fields.html.slim
+++ b/app/views/backoffice/pages/_data_layers_fields.html.slim
@@ -12,7 +12,9 @@
       .row.file
         .grid-sm-6.name
           p = f.object.table_name
-        .grid-sm-6
+        .grid-sm-1
+          = link_to_remove_association '×', f, class: 'btn -delete'
+        .grid-sm-5
           = f.input_field :layer_column_alias, placeholder: "Column alias"
     .nested-fields
       .row

--- a/app/views/backoffice/pages/_data_layers_fields.html.slim
+++ b/app/views/backoffice/pages/_data_layers_fields.html.slim
@@ -13,7 +13,7 @@
         .grid-sm-6.name
           p = f.object.table_name
         .grid-sm-1
-          = link_to_remove_association '×', f, class: 'btn -delete'
+          = link_to_remove_association '×', f, class: 'btn -delete -inside-input'
         .grid-sm-5
           = f.input_field :layer_column_alias, placeholder: "Column alias"
     .nested-fields

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,8 @@ Rails.application.routes.draw do
     root 'case_studies#index', as: 'dashboard'
 
     get 'data-layers/:id', to: 'data_layers#index'
+    delete 'data-layers/:id', to: 'data_layers#destroy'
+
   end
 
   resources :case_studies, only: [:index, :show], param: :slug, path: 'case-studies' do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,11 +12,8 @@ Rails.application.routes.draw do
     resources :users, except: [:show]
     resources :organizations, except: [:show]
 
+    resources :data_layers, path: "data-layers", only: [:destroy, :show]
     root 'case_studies#index', as: 'dashboard'
-
-    get 'data-layers/:id', to: 'data_layers#index'
-    delete 'data-layers/:id', to: 'data_layers#destroy'
-
   end
 
   resources :case_studies, only: [:index, :show], param: :slug, path: 'case-studies' do


### PR DESCRIPTION
This PR adds the feature of removing **completely** a data set and its relations.
![image](https://cloud.githubusercontent.com/assets/704210/13665595/8c5429b6-e6ad-11e5-99d6-fe40543b7edc.png)
Note that `×` located at the end of the file _input_.

It asks for confirmation.
![image](https://cloud.githubusercontent.com/assets/704210/13665635/c08bec8c-e6ad-11e5-92dc-df2f382ade7b.png)

And deletes it.

Maybe we might want to check the styles definitions for that `×` and the back end handling as I didn't mean to change a lot of things. ( @simaob @j8seangel  )
