### PR TITLE
Support multiple workers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,7 @@ gem 'deep_cloneable', '~> 2.1.1'
 
 # Jobs managment
 gem 'resque', "~> 1.22.0"
+gem 'resque-pool'
 
 # API
 # gem 'sdoc', '~> 0.4.0', group: :doc

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -211,6 +211,9 @@ GEM
       redis-namespace (~> 1.0)
       sinatra (>= 0.9.2)
       vegas (~> 0.1.2)
+    resque-pool (0.6.0)
+      rake
+      resque (~> 1.22)
     rspec-core (3.4.2)
       rspec-support (~> 3.4.0)
     rspec-expectations (3.4.0)
@@ -318,6 +321,7 @@ DEPENDENCIES
   rails_12factor
   redcarpet
   resque (~> 1.22.0)
+  resque-pool
   rspec-rails (~> 3.0)
   sass-rails (~> 5.0)
   simple_form

--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 web: bundle exec puma -t 5:5 -p ${PORT:-3000} -e ${RACK_ENV:-development}
 
-resque: env QUEUE=* TERM_CHILD=1 RESQUE_TERM_TIMEOUT=7 bundle exec rake resque:work
+worker: bundle exec resque-pool

--- a/config/resque-pool.yml
+++ b/config/resque-pool.yml
@@ -1,0 +1,1 @@
+carto_table_import: 3

--- a/lib/tasks/resque.rake
+++ b/lib/tasks/resque.rake
@@ -1,3 +1,13 @@
 require "resque/tasks"
 
 task "resque:setup" => :environment
+
+# this task will get called before resque:pool:setup
+# and preload the rails environment in the pool manager
+task "resque:pool:setup" do
+  # close any sockets or files in pool manager
+  ActiveRecord::Base.connection.disconnect!
+  Resque::Pool.after_prefork do
+    ActiveRecord::Base.establish_connection
+  end
+end


### PR DESCRIPTION
In development now we have to launch workers with: 

`RAILS_ENV=development bundle exec resque-pool`
