### PR TITLE
Fixes bug with callback on data_layers model

### DIFF
--- a/app/controllers/backoffice/pages_controller.rb
+++ b/app/controllers/backoffice/pages_controller.rb
@@ -60,7 +60,7 @@ class Backoffice::PagesController < BackofficeController
 
     def upload_pending_files
       @page.data_layers.each do |d|
-        Resque.enqueue(CartoDbImporter, d.id) if d.import_status == "pending"
+        Resque.enqueue(CartoDbImporter, d.id) if d.import_status == ImportStatus::PENDING
       end
     end
 

--- a/app/models/data_layer.rb
+++ b/app/models/data_layer.rb
@@ -25,7 +25,7 @@ class DataLayer < ActiveRecord::Base
 
 
 
-  validates :shapefile, attachment_presence: true
+  validates :shapefile, attachment_presence: true, on: :create
 
   attr_accessor :cloning
 
@@ -35,7 +35,7 @@ class DataLayer < ActiveRecord::Base
   private
 
   def check_is_ready
-    if self.import_status == 'complete'
+    if self.import_status == ImportStatus::COMPLETE
       if (self.raster_type.blank? && (!self.layer_column.blank? || !self.year.blank?))
           self.is_ready = true
       elsif (!self.raster_categories.blank?)
@@ -44,6 +44,7 @@ class DataLayer < ActiveRecord::Base
         self.is_ready = false
       end
     end
+    true
   end
 
   def remove_cartodb_table

--- a/app/workers/carto_db_importer.rb
+++ b/app/workers/carto_db_importer.rb
@@ -32,10 +32,11 @@ class CartoDbImporter
       import_status = CartoDb.import_status(queue_id)
       i += 1
     end
-    layer.update_attributes(import_status: import_status["state"])
-    layer.update_attributes(table_name: import_status["table_name"])
+    layer.table_name = import_status["table_name"]
+    layer.import_status = import_status["state"]
     layer.shapefile.destroy
     layer.shapefile.clear
+    layer.save
 
     File.delete(file) unless Rails.env.development?
   end


### PR DESCRIPTION
The callback is used to defined the value of is_ready for the
data_layer.

But when that value is false the callback's return value is also false,
which causes the record to not be saved. The return value needs to be
true always, regardless of the value of is_ready.
