### PR TITLE
Fixes duplicated pages on public interface.

### DIFF
--- a/app/controllers/case_studies_controller.rb
+++ b/app/controllers/case_studies_controller.rb
@@ -17,8 +17,7 @@ class CaseStudiesController < ApplicationController
 
   def show
     @tags = Tag.all
-    @case_study = CaseStudy.published.where(slug: params[:slug]).
-      includes(:contacts, :valid_pages).first
+    @case_study = CaseStudy.published.where(slug: params[:slug]).first
 
     gon.case_study = @case_study.
       as_json(include: [:contacts, {valid_pages: {include: [:data_layers, :charts, :interest_points]}}])
@@ -28,8 +27,7 @@ class CaseStudiesController < ApplicationController
   def preview
     if user_signed_in?
       @tags = Tag.all
-      @case_study = CaseStudy.where(slug: params[:slug]).
-        includes(:contacts, :valid_pages).first
+      @case_study = CaseStudy.where(slug: params[:slug]).first
 
       gon.case_study = @case_study.
         to_json(include: [:contacts, {pages: {include: [:data_layers, :charts]}}])

--- a/app/controllers/case_studies_controller.rb
+++ b/app/controllers/case_studies_controller.rb
@@ -30,7 +30,7 @@ class CaseStudiesController < ApplicationController
       @case_study = CaseStudy.where(slug: params[:slug]).first
 
       gon.case_study = @case_study.
-        to_json(include: [:contacts, {pages: {include: [:data_layers, :charts]}}])
+        as_json(include: [:contacts, {valid_pages: {include: [:data_layers, :charts, :interest_points]}}])
       gon.cartodb_user = ENV["CDB_USERNAME"]
     else
       not_found

--- a/app/models/case_study.rb
+++ b/app/models/case_study.rb
@@ -10,9 +10,10 @@ class CaseStudy < ActiveRecord::Base
   has_many :contacts
   has_many :pages, dependent: :destroy
   has_many :valid_pages, -> {
-    joins("LEFT OUTER JOIN data_layers ON data_layers.page_id = pages.id").includes(:charts, :interest_points).
+    joins("LEFT OUTER JOIN data_layers ON data_layers.page_id = pages.id").
+    distinct.includes(:charts, :interest_points).
     where("(data_layers.is_ready = 't' AND pages.page_type IN (?)) OR (pages.page_type = ?)",
-          [PageType::TIMELINE, PageType::MAP], PageType::TEXT ) },
+          [PageType::TIMELINE, PageType::MAP], PageType::TEXT )},
     class_name: 'Page'
 
   belongs_to :organization


### PR DESCRIPTION
Removes includes method from the controller as in this case N is 1 so
we do not need to use includes to avoid issues
with N+1 queries being triggered.

This also fixes a bug where duplicated pages were being fetched because
of the lack of distinct on the valid_pages association.

Another reason to remove includes from the controller is related with a
bug in ActiveRecord whereby the includes method strips group and other closes
from associations it tries to include. This bug is currently stale. See
issue: https://github.com/rails/rails/issues/15854
