### PR TITLE
Adds foreign keys to database for referencial integrity

### DIFF
--- a/db/migrate/20160411182713_add_foreign_keys_to_database.rb
+++ b/db/migrate/20160411182713_add_foreign_keys_to_database.rb
@@ -1,0 +1,8 @@
+class AddForeignKeysToDatabase < ActiveRecord::Migration
+  def change
+    add_foreign_key :data_layers, :pages
+    add_foreign_key :interest_points, :pages
+    add_foreign_key :pages, :case_studies
+    add_foreign_key :contacts, :case_studies
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160329155832) do
+ActiveRecord::Schema.define(version: 20160411182713) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -171,4 +171,8 @@ ActiveRecord::Schema.define(version: 20160329155832) do
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
   add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
 
+  add_foreign_key "contacts", "case_studies"
+  add_foreign_key "data_layers", "pages"
+  add_foreign_key "interest_points", "pages"
+  add_foreign_key "pages", "case_studies"
 end


### PR DESCRIPTION
Requires:

`rake db:migrate`

Beware that it might throw some exceptions when running. This will be related with orphan objects, so you'll probably want to delete them from your database anyway and run again! =)
