### PR TITLE
Ensure database referencial consistency

### DIFF
--- a/app/models/case_study.rb
+++ b/app/models/case_study.rb
@@ -7,7 +7,7 @@ class CaseStudy < ActiveRecord::Base
 
   acts_as_taggable
 
-  has_many :contacts
+  has_many :contacts, dependent: :destroy
   has_many :pages, dependent: :destroy
   has_many :valid_pages, -> {
     joins("LEFT OUTER JOIN data_layers ON data_layers.page_id = pages.id").

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -5,8 +5,8 @@ class Page < ActiveRecord::Base
 
   belongs_to :case_study
   has_many :data_layers, dependent: :destroy
-  has_many :interest_points
-  has_and_belongs_to_many :charts
+  has_many :interest_points, dependent: :destroy
+  has_and_belongs_to_many :charts, dependent: :destroy
   has_attached_file :background, styles: {
     medium: '385x200#',
     large: '1920x1080#'


### PR DESCRIPTION
When deleting a case_study or a page make sure to delete dependent objects
