### PR TITLE
Some improvements before final delivery.

### DIFF
--- a/app/controllers/backoffice/data_layers_controller.rb
+++ b/app/controllers/backoffice/data_layers_controller.rb
@@ -11,8 +11,12 @@ class Backoffice::DataLayersController < BackofficeController
   end
 
   def destroy
+    @page = @data_layer.page
     @data_layer.destroy
-    render json: true
+    respond_to do |format|
+      format.json { render json: true }
+      format.html { redirect_to edit_backoffice_case_study_page_path(@page.case_study, @page) }
+    end
   end
 
 

--- a/app/views/backoffice/pages/edit.html.slim
+++ b/app/views/backoffice/pages/edit.html.slim
@@ -17,13 +17,17 @@ section.l-main
         - layersUploading = false
         - layersError = false
         - feedbackMsg = ''
+        - erroredLayer = nil
         - @page.data_layers.each do |d|
           - if [ImportStatus::PENDING, ImportStatus::UPLOADING].include?(d.import_status)
             - layersUploading = true
-            - feedbackMsg = 'Datasets files are being uploaded, please wait and page will reload automatically or return in a little while'
+            - feedbackMsg = "Datasets files are being uploaded, please wait and page will reload automatically or return in a moment."
+            - if d.import_attempt > 0
+              - feedbackMsg = feedbackMsg + " Import started #{d.import_attempt} minutes ago. Larger files will take longer to import. The application will allow 1 hour before assuming a failure in the upload."
             - break
           - if d.import_status == ImportStatus::FAILURE
             - layersError = true
+            - erroredLayer = d
             - feedbackMsg = 'There was an error uploading the file, please remove it and try again later'
             - break
 
@@ -32,9 +36,13 @@ section.l-main
             div class=(layersUploading ? '_is-loading':'')
               span.loading-msg = feedbackMsg
             - if layersError
-              = link_to t('delete'),
-                backoffice_case_study_page_path(case_study_id: @page.case_study.id,
-                id: @page.id), method: :delete, class: 'btn -alt'
+              - if @page.data_layers.count > 1
+                = link_to t('delete'), backoffice_data_layer_path(erroredLayer),
+                  method: :delete, class: 'btn -alt'
+              - else
+                = link_to t('delete'),
+                  backoffice_case_study_page_path(case_study_id: @page.case_study.id,
+                  id: @page.id), method: :delete, class: 'btn -alt'
         - else
           = simple_form_for @page, url: backoffice_case_study_page_path, html: { multipart: true }, html: { class: "exit-saving"}  do |f|
             - if @page.page_type == PageType::TEXT
@@ -44,15 +52,13 @@ section.l-main
               = render 'backoffice/pages/edit_form/edit_form_timeline', f: f
             - else 
               = render 'backoffice/pages/edit_form/edit_form_map', f: f
-            
+
             = render 'backoffice/pages/edit_form/edit_form_footer', f: f
-            
             / = render 'edit_form', f: f
-            
           ._hidden
             #feedbackAnalyzing
               .loading-container
                 div._is-loading
                   span.loading-msg
                   | The datalayers are being analyzed,
-                    please wait a little while
+                    please wait a moment.

--- a/app/workers/carto_db_importer.rb
+++ b/app/workers/carto_db_importer.rb
@@ -26,11 +26,12 @@ class CartoDbImporter
     import_status = CartoDb.import_status(queue_id)
     i = 0
     # posibles status: enqueued, pending, uploading, unpacking, importing, guessing, complete, or failure.
-    while i < 120
+    while i < 60
       break if [ImportStatus::COMPLETE, ImportStatus::FAILURE].include?(import_status["state"])
       sleep(60)
       import_status = CartoDb.import_status(queue_id)
       i += 1
+      layer.update_attributes(import_attempt: i)
     end
     layer.table_name = import_status["table_name"]
     layer.import_status = import_status["state"]

--- a/db/migrate/20160912145821_add_import_attempt_to_data_layers.rb
+++ b/db/migrate/20160912145821_add_import_attempt_to_data_layers.rb
@@ -1,0 +1,5 @@
+class AddImportAttemptToDataLayers < ActiveRecord::Migration
+  def change
+    add_column :data_layers, :import_attempt, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160411182713) do
+ActiveRecord::Schema.define(version: 20160912145821) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -87,6 +87,7 @@ ActiveRecord::Schema.define(version: 20160411182713) do
     t.string   "raster_categories"
     t.text     "raster_color_input"
     t.boolean  "is_ready"
+    t.integer  "import_attempt",         default: 0
   end
 
   add_index "data_layers", ["page_id"], name: "index_data_layers_on_page_id", using: :btree


### PR DESCRIPTION
- Shows feedback about time elapsed since upload started.
- Avoids deleting whole pages if they have more than one data_layer and a new upload fails.

**requires** `rake db:migrate`
